### PR TITLE
ci: resolve zizmor security findings in GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     pull-request-branch-name:
       separator: "/"
     commit-message:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -8,10 +8,14 @@ jobs:
   markdownlint:
     name: Markdown Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
         with:
             globs: "**/*.md"


### PR DESCRIPTION
Resolves all findings reported by `zizmor .github/`:

- **unpinned-uses**: Pin `actions/checkout` and `DavidAnson/markdownlint-cli2-action` to full commit SHAs with inline version comments
- **artipacked**: Add `persist-credentials: false` to the checkout step to prevent credential persistence in artifacts
- **excessive-permissions**: Scope job permissions to `contents: read` instead of relying on broad workflow defaults
- **dependabot-cooldown**: Add `cooldown` block (7-day default, 14-day for major bumps) to the Dependabot config