### PR TITLE
ci(deps): change github-actions dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
Changes the dependabot check interval for github-actions from daily to weekly.