### PR TITLE
chore: add pre-commit hooks for linting and secrets scanning

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,5 +1,5 @@
 
-name: markdownlint 
+name: markdownlint
 
 on:
   pull_request:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.0
+    hooks:
+      - id: markdownlint-cli2-docker
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: mixed-line-ending
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,32 @@ markdownlint "**/*.md" "#node_modules"
 
 There are no test suites in this repository.
 
+### Pre-commit Hooks
+
+This repository uses [pre-commit](https://pre-commit.com/) to run linting and
+security checks automatically before each commit. Configuration lives in
+`.pre-commit-config.yaml` and includes:
+
+- `actionlint` - lints GitHub Actions workflow files
+- `gitleaks` - detects hardcoded secrets
+- `markdownlint-cli2-docker` - lints markdown files
+- `pre-commit-hooks` - trailing whitespace, end-of-file fixer, YAML
+  validation, merge conflict markers, large file checks, mixed line endings
+- `zizmor` - scans GitHub Actions workflows for security issues
+
+Install and enable the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all hooks against all files manually:
+
+```bash
+pre-commit run --all-files
+```
+
 ### GitHub Actions
 
 The repository includes a CI workflow (`.github/workflows/markdownlint.yml`) that runs on pull requests.
@@ -84,7 +110,8 @@ The repository includes a CI workflow (`.github/workflows/markdownlint.yml`) tha
 
 1. Create a branch for your changes
 2. Make edits following the style guidelines above
-3. Run markdownlint before committing
+3. Run markdownlint before committing (pre-commit hooks will also run
+   automatically on `git commit`)
 4. Submit a pull request (CI will run linting automatically)
 
 ---


### PR DESCRIPTION
Adds `.pre-commit-config.yaml` with actionlint, gitleaks, markdownlint-cli2-docker, standard pre-commit-hooks (trailing whitespace, EOF fixer, YAML checks, merge conflict detection, large file checks, mixed line endings), and zizmor.

Documents installation and usage in AGENTS.md. Also fixes a trailing whitespace issue flagged in `.github/workflows/markdownlint.yml` by the new hooks.